### PR TITLE
Support for multiple feature sets per job

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,29 @@
 Change log
 ==========
 
+## 0.10.0
+Better support for running jobs with multiple feature sets. Also
+checks for absense of `_SUCCESS` file prior to writing features to sink,
+writing the file at the end of the job once all data is written.
+
+- Changed return type of `FeatureSink.write`. Implementations must now
+ return the set `Path`s written to so they can be committed (`_SUCCESS`
+ file written) at the end of the job. While not enforced, implementations
+ should also check that paths are not already committed when writing new
+ data.
+- Moved `Partitions` instance from `ScaldingDataSource` into top-level
+ `commbank.coppersmith.scalding` package and made directly available
+ via api import.
+
+ ### Upgrading
+ Custom sink implementations need to return the set of `Path`s written
+ to from the `write` method. If writing to a single, fixed partition, the
+ new FixedPartition case class could be used as sink's partition, making
+ it straight forward to retrieve the path written to.
+
+ References to `commbank.coppersmith.scalding.ScaldingDataSource.Partitions`
+ should be replaced with `commbank.coppersmith.scalding.Partitions`.
+
 ## 0.9.0
 - Move implicits into a separate object (`Coppersmith`) within the API
   package object.

--- a/examples/src/main/scala/commbank/coppersmith/examples/FlatFeatureSink.scala
+++ b/examples/src/main/scala/commbank/coppersmith/examples/FlatFeatureSink.scala
@@ -14,15 +14,19 @@
 
 package commbank.coppersmith.examples.userguide
 
+import org.apache.hadoop.fs.Path
+
 import com.twitter.scalding.typed.TypedPipe
-import com.twitter.scalding.{Execution, TypedTsv}
+import com.twitter.scalding.TypedTsv
+
 import commbank.coppersmith.Feature.Time
 import commbank.coppersmith.Feature.Value.{Decimal, Integral, Str}
 import commbank.coppersmith.FeatureValue
-import commbank.coppersmith.scalding.FeatureSink
+import commbank.coppersmith.scalding.FeatureSink, FeatureSink.WriteResult
 
 case class FlatFeatureSink(output: String) extends FeatureSink {
-  override def write(features: TypedPipe[(FeatureValue[_], Time)]): Execution[Unit] = {
+  def path = new Path(output)
+  override def write(features: TypedPipe[(FeatureValue[_], Time)]): WriteResult = {
 
     val featurePipe = features.map { case (fv, t) =>
       val featureValue = (fv.value match {
@@ -32,6 +36,6 @@ case class FlatFeatureSink(output: String) extends FeatureSink {
       }).getOrElse("")
       s"${fv.entity}|${fv.name}|${featureValue}"
     }
-    featurePipe.writeExecution(TypedTsv[String](output)).unit
+    featurePipe.writeExecution(TypedTsv[String](output)).map(_ => Right(Set(path)))
   }
 }

--- a/examples/src/main/scala/commbank/coppersmith/examples/Pivot.scala
+++ b/examples/src/main/scala/commbank/coppersmith/examples/Pivot.scala
@@ -11,7 +11,7 @@ import commbank.coppersmith.api.scalding._
 import commbank.coppersmith.examples.thrift.Movie
 
 case class PivotFeaturesConfig(conf: Config) extends FeatureJobConfig[Movie] {
-  val partitions     = ScaldingDataSource.Partitions.unpartitioned
+  val partitions     = Partitions.unpartitioned
   val movies         = HiveTextSource[Movie, Nothing](new Path("data/movies"), partitions)
 
   val featureSink    = EavtSink.configure("userguide", new Path("dev"), "movies")

--- a/project/FeatureJobGenerator.scala
+++ b/project/FeatureJobGenerator.scala
@@ -63,7 +63,7 @@ object FeatureJobGenerator {
           |import commbank.coppersmith.examples.thrift.$thriftImport
           |
           |case class ${name}Config(conf: Config) extends FeatureJobConfig[$typeParams] {
-          |  val partitions     = ScaldingDataSource.Partitions.unpartitioned
+          |  val partitions     = Partitions.unpartitioned
           |  $dataSources
           |
           |  val featureSource  = $name.source.bind($binding)
@@ -99,6 +99,4 @@ object FeatureJobGenerator {
       if !existing.contains(name)
     } yield new FeatureJobConstructor(name, typeParams)
   }
-
-
 }

--- a/scalding/src/main/scala/commbank/coppersmith/api/scalding/package.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/api/scalding/package.scala
@@ -23,6 +23,9 @@ package object scalding {
   type FeatureJobConfig[S] = commbank.coppersmith.scalding.FeatureJobConfig[S]
   type SimpleFeatureJob = commbank.coppersmith.scalding.SimpleFeatureJob
 
+  val FeatureSetExecutions = commbank.coppersmith.scalding.FeatureSetExecutions
+  val FeatureSetExecution = commbank.coppersmith.scalding.FeatureSetExecution
+
   val ScaldingDataSource = commbank.coppersmith.scalding.ScaldingDataSource
   val HiveTextSource = commbank.coppersmith.scalding.HiveTextSource
   val TypedPipeSource = commbank.coppersmith.scalding.TypedPipeSource

--- a/scalding/src/main/scala/commbank/coppersmith/api/scalding/package.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/api/scalding/package.scala
@@ -26,7 +26,8 @@ package object scalding {
   val FeatureSetExecutions = commbank.coppersmith.scalding.FeatureSetExecutions
   val FeatureSetExecution = commbank.coppersmith.scalding.FeatureSetExecution
 
-  val ScaldingDataSource = commbank.coppersmith.scalding.ScaldingDataSource
+  val Partitions = commbank.coppersmith.scalding.Partitions
+  val PathComponents = commbank.coppersmith.scalding.Partitions
   val HiveTextSource = commbank.coppersmith.scalding.HiveTextSource
   val TypedPipeSource = commbank.coppersmith.scalding.TypedPipeSource
   val EavtSink = commbank.coppersmith.scalding.EavtSink

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/HiveSupport.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/HiveSupport.scala
@@ -1,0 +1,163 @@
+//
+// Copyright 2016 Commonwealth Bank of Australia
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//        http://www.apache.org/licenses/LICENSE-2.0
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+package commbank.coppersmith.scalding
+
+import com.twitter.algebird.Aggregator
+import com.twitter.scalding.typed.{PartitionedTextLine, TypedPipe}
+import com.twitter.scalding.{Execution, TupleConverter, TupleSetter}
+
+import org.apache.hadoop.fs.Path
+
+import scalaz.std.list.listInstance
+import scalaz.syntax.bind.ToBindOps
+import scalaz.syntax.functor.ToFunctorOps
+import scalaz.syntax.std.list.ToListOpsFromList
+import scalaz.syntax.traverse.ToTraverseOps
+
+import au.com.cba.omnia.maestro.api._, Maestro._
+import au.com.cba.omnia.maestro.scalding.ConfHelper.createUniqueFilenames
+
+import Partitions.PathComponents
+import FeatureSink.{AttemptedWriteToCommitted, WriteResult}
+
+// Maestro's HiveTable currently assumes the underlying format to be Parquet. This code generalises
+// code from different feature gen projects, which supports storing the final EAVT records as text.
+object HiveSupport {
+  trait DelimiterConflictStrategy[T] {
+    def handle(row: T, result: String, sep: String): Option[String]
+  }
+  // Use if field values are assumed to never contain the separator character
+  case class FailJob[T]() extends DelimiterConflictStrategy[T] {
+    def handle(row: T, result: String, sep: String) =
+      sys.error(s"field '$result' in '$row' contains the specified delimiter '$sep'")
+  }
+
+  case class HiveConfig[T <: ThriftStruct : Manifest, P](
+    partition: Partition[T, P],
+    database:  String,
+    path:      Path,
+    tablename: String,
+    delimiter: String,
+    dcs:       DelimiterConflictStrategy[T]
+  )
+
+  def writeTextTable[
+    T <: ThriftStruct with Product : Manifest,
+    P : TupleSetter : TupleConverter : PathComponents
+  ](
+    conf: HiveConfig[T, P],
+    pipe: TypedPipe[T]
+  ): WriteResult = {
+
+    import conf.partition
+    val partitioned: TypedPipe[(P, String)] = pipe.map(v =>
+      partition.extract(v) -> serialise[T](v, conf.delimiter, "\\N")(conf.dcs)
+    )
+
+    // Use an intermediate temporary directory to write pipe in order to avoid race condition that
+    // occurs when two parallel executions are writing to the same sink in two different Cascading
+    // Flow instances. Race condition occurs when shared _temporary directory is deleted via
+    // cascading.tap.hadoop.util.Hadoop18TapUtil.cleanupJob when Hadoop18TapUtil.isInflow returns
+    // false and before the other execution has copied its results.
+    Execution.fromHdfs(Hdfs.createTempDir()).flatMap(tempDir => {
+      val sink = PartitionedTextLine(tempDir.toString, partition.pattern);
+      {
+        for {
+                         // Use append semantics for now as an interim fix to address #97
+                         // Check if this is still relevant once #137 is addressed
+          _           <- partitioned.writeExecution(sink).withSubConfig(createUniqueFilenames(_))
+          oPValues    <- partitioned.aggregate(Aggregator.toSet.composePrepare(_._1)).toOptionExecution
+          oPartitions  = oPValues.map(_.toSet.toList).toList.flatten.toNel.map(pValues =>
+                           Partitions(conf.partition, pValues.head, pValues.tail: _*)
+                         )
+          result      <- moveToTarget(tempDir, conf.path, oPartitions)
+          _           <- Execution.fromHive(ensureTextTableExists(conf))
+        } yield result
+      }.ensure(Execution.fromHdfs(Hdfs.delete(tempDir, recDelete = true)))
+    })
+  }
+
+  private def moveToTarget(
+    sourceDir:  Path,
+    targetDir:  Path,
+    partitions: Option[Partitions[_]]
+  ): WriteResult = {
+    val partitionRelPaths = partitions.map(_.relativePaths).getOrElse(List())
+
+    partitionRelPaths.foldLeft[WriteResult](Execution.from(Right(Set())))((acc, partitionRelPath) =>
+      acc.flatMap {
+        case l@Left(_) => Execution.from(l)
+        case Right(pathsSoFar) => {
+          val sourcePartition = new Path(sourceDir, partitionRelPath)
+          val targetPartition = new Path(targetDir, partitionRelPath)
+          FeatureSink.isCommitted(targetPartition).flatMap {
+            case true => Execution.from(Left(AttemptedWriteToCommitted(targetPartition)))
+            case false =>
+              Execution.fromHdfs(
+                for {
+                  parts <- Hdfs.glob(sourcePartition, "*")
+                  _     <- Hdfs.mkdirs(targetPartition)
+                  _     <- parts.map(part =>
+                             Hdfs.move(part, new Path(targetPartition, part.getName))
+                           ).sequence
+                } yield Right(pathsSoFar + targetPartition)
+              )
+          }
+        }
+      }
+    )
+  }
+
+  def ensureTextTableExists[T <: ThriftStruct : Manifest](conf: HiveConfig[T, _]): Hive[Unit] =
+    for {
+           // Hive.createTextTable is idempotent - it will no-op if the table already exists,
+           // assuming the schema matches exactly
+      _ <- Hive.createTextTable[T](
+             database         = conf.database,
+             table            = conf.tablename,
+             partitionColumns = conf.partition.fieldNames.map(_ -> "string"),
+             location         = Option(conf.path),
+             delimiter        = conf.delimiter
+           )
+      _ <- Hive.queries(List(s"use `${conf.database}`", s"msck repair table `${conf.tablename}`"))
+    } yield ()
+
+  // Adapted from ParseUtils in util.etl project
+  private def serialise[T <: Product](row: T, sep: String, none: String)
+                                     (implicit dcs: DelimiterConflictStrategy[T]): String = {
+
+    def delimiterConflict(s: String) = s.contains(sep)
+
+    row.productIterator.flatMap(value => {
+      val result = value match {
+        case Some(x) => x
+        case None    => none
+        case any     => any
+      }
+      if (delimiterConflict(result.toString)) {
+        dcs.handle(row, value.toString, sep).map(r =>
+          if (delimiterConflict(r)) {
+            sys.error(("Delimiter conflict not handled adequately: " +
+                       s"result '$r' from '$row' still contains the specified delimiter '$sep'"))
+          } else {
+            r
+          }
+        )
+      } else {
+        Option(result)
+      }
+    }).mkString(sep)
+  }
+}

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/Partitions.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/Partitions.scala
@@ -1,0 +1,62 @@
+//
+// Copyright 2016 Commonwealth Bank of Australia
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//        http://www.apache.org/licenses/LICENSE-2.0
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+package commbank.coppersmith.scalding
+
+import scalaz.NonEmptyList
+import scalaz.syntax.std.list.ToListOpsFromList
+
+import org.apache.hadoop.fs.Path
+
+import au.com.cba.omnia.maestro.api.Partition
+
+import Partitions.PathComponents
+
+/** A concrete set of partition values that can be used to construct a relative path
+  * based on a pattern that incorporates those values as format args. Use the various
+  * `Partitions.apply` methods to create instances, or the `unpartitioned` value for
+  * unpartitioned data.
+  */
+case class Partitions[P : PathComponents] private(pattern: String, values: List[P]) {
+  /** Paths relative to the supplied `basePath` */
+  def toPaths(basePath: Path): List[Path] =
+    oPaths.map(_.map(new Path(basePath, _))).map(_.list).getOrElse(List(new Path(basePath, "*")))
+
+  def relativePaths: List[Path] = oPaths.map(_.list).getOrElse(List(new Path(".")))
+
+  /** Relative paths that this instance represents, or `None` if `values` is empty. */
+  def oPaths: Option[NonEmptyList[Path]] = values.toNel.map(_.map(value =>
+   new Path(pattern.format(implicitly[PathComponents[P]].toComponents((value)): _*))
+  ))
+}
+
+object Partitions {
+  def apply[P : PathComponents](underlying: Partition[_, P], first: P, rest: P*): Partitions[P] =
+    Partitions(underlying.pattern, first, rest: _*)
+
+  def apply[P : PathComponents](pattern: String, first: P, rest: P*): Partitions[P] =
+    Partitions(pattern, (first +: rest).toList)
+
+  def unpartitioned = Partitions[Nothing]("", List())(PathComponents[Nothing](List()))
+
+  case class PathComponents[P](toComponents: P => List[String])
+
+  object PathComponents {
+    import shapeless.syntax.std.tuple.productTupleOps
+    implicit val StringToPath       = PathComponents[String](List(_))
+    implicit val StringTuple2ToPath = PathComponents[(String, String)](_.toList)
+    implicit val StringTuple3ToPath = PathComponents[(String, String, String)](_.toList)
+    implicit val StringTuple4ToPath = PathComponents[(String, String, String, String)](_.toList)
+  }
+}

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/ScaldingDataSource.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/ScaldingDataSource.scala
@@ -29,38 +29,6 @@ import au.com.cba.omnia.maestro.core.codec.{DecodeOk, DecodeError, ParseError, N
 
 import commbank.coppersmith.DataSource
 
-object ScaldingDataSource {
-  object Partitions {
-    def apply[P : PathComponents](underlying: Partition[_, P], first: P, rest: P*): Partitions[P] =
-      Partitions(underlying.pattern, first, rest: _*)
-
-    def apply[P : PathComponents](pattern: String, first: P, rest: P*): Partitions[P] =
-      Partitions(pattern, (first +: rest).toList)
-
-    def unpartitioned = Partitions[Nothing]("", List())
-  }
-  case class Partitions[P : PathComponents] private(pattern: String, values: List[P]) {
-    def toPaths(basePath: Path): List[Path] =
-      oPaths.map(_.map(new Path(basePath, _))).getOrElse(List(new Path(basePath, "*")))
-
-    def relativePaths: List[Path] = oPaths.getOrElse(List(new Path(".")))
-
-    def oPaths: Option[List[Path]] = values.toNel.map(_.list.map(value =>
-     new Path(pattern.format(implicitly[PathComponents[P]].toComponents((value)): _*))
-    ))
-  }
-
-  case class PathComponents[P](toComponents: P => List[String])
-  import shapeless.syntax.std.tuple.productTupleOps
-  implicit val EmptyToPath        = PathComponents[Nothing](List())
-  implicit val StringToPath       = PathComponents[String](List(_))
-  implicit val StringTuple2ToPath = PathComponents[(String, String)](_.toList)
-  implicit val StringTuple3ToPath = PathComponents[(String, String, String)](_.toList)
-  implicit val StringTuple4ToPath = PathComponents[(String, String, String, String)](_.toList)
-}
-
-import ScaldingDataSource.Partitions
-
 case class HiveTextSource[S <: ThriftStruct : Decode](
   paths: List[Path],
   delimiter:  String

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/EavtSinkSpec.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/EavtSinkSpec.scala
@@ -27,7 +27,7 @@ import au.com.cba.omnia.maestro.api._, Maestro._
 import au.com.cba.omnia.maestro.test.Records
 
 import au.com.cba.omnia.thermometer.core.Thermometer._
-import au.com.cba.omnia.thermometer.fact.PathFactoids.{exists, records}
+import au.com.cba.omnia.thermometer.fact.PathFactoids.{exists, missing, records}
 import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 
 import commbank.coppersmith._, Arbitraries._, Feature.Value
@@ -35,11 +35,13 @@ import ScaldingArbitraries._
 import thrift.Eavt
 
 class EavtSinkSpec extends ThermometerHiveSpec with Records { def is = s2"""
-    Writing features to a EavtSink
-      writes all feature values          $featureValuesOnDiskMatch        ${tag("slow")}
-      writes multiple results            $multipleValueSetsOnDiskMatch    ${tag("slow")}
-      exposes features through hive      $featureValuesInHiveMatch        ${tag("slow")}
-      writes all partitions with SUCCESS $expectedPartitionsMarkedSuccess ${tag("slow")}
+    Writing features to an EavtSink
+      writes all feature values            $featureValuesOnDiskMatch        ${tag("slow")}
+      writes multiple results              $multipleValueSetsOnDiskMatch    ${tag("slow")}
+      exposes features through hive        $featureValuesInHiveMatch        ${tag("slow")}
+      commits all partitions with SUCCESS  $expectedPartitionsMarkedSuccess ${tag("slow")}
+      fails if sink is committed           $writeFailsIfSinkCommitted       ${tag("slow")}
+      fails to commit if sink is committed $commitFailsIfSinkCommitted      ${tag("slow")}
   """
 
   implicit val arbConfig: Arbitrary[EavtSink.Config] =
@@ -134,11 +136,71 @@ class EavtSinkSpec extends ThermometerHiveSpec with Records { def is = s2"""
       ).list.toSet.toSeq
       withEnvironment(path(getClass.getResource("/").toString)) {
         val sink = EavtSink(eavtConfig)
-        executesSuccessfully(sink.write(valuePipe(vs, dateTime)))
+        val writeResult = executesSuccessfully(sink.write(valuePipe(vs, dateTime)))
+
+        // Not yet committed; _SUCCESS should be missing
         facts(
           expectedPartitions.map { case (year, month, day) =>
-            path(s"${eavtConfig.hiveConfig.path}/year=$year/month=$month/day=$day/_SUCCESS") ==> exists
+            path(s"${eavtConfig.hiveConfig.path}/year=$year/month=$month/day=$day/_SUCCESS") ==> missing
           }: _*
+        )
+
+        writeResult.fold(
+          e => failure("Unexpected write failure: " + e),
+          paths => {
+            val commitResult = executesSuccessfully(FeatureSink.commit(paths))
+            facts(
+              expectedPartitions.map { case (year, month, day) =>
+                path(s"${eavtConfig.hiveConfig.path}/year=$year/month=$month/day=$day/_SUCCESS") ==> exists
+              }: _*
+            )
+            commitResult must beRight
+          }
+        )
+      }
+    }}.set(minTestsOk = 5)
+
+  def writeFailsIfSinkCommitted =
+    forAll { (vs: NonEmptyList[FeatureValue[Value]], eavtConfig: EavtSink.Config, dateTime: DateTime) =>  {
+      val expected = vs.map(EavtSink.toEavt(_, dateTime.getMillis)).list
+      withEnvironment(path(getClass.getResource("/").toString)) {
+        val sink = EavtSink(eavtConfig)
+        val writeResult = executesSuccessfully(sink.write(valuePipe(vs, dateTime)))
+
+        writeResult.fold(
+          e => failure("Unexpected write failure: " + e),
+          paths => {
+            executesSuccessfully(FeatureSink.commit(paths))
+
+            val secondWriteResult = executesSuccessfully(sink.write(valuePipe(vs, dateTime)))
+
+            // Make sure no duplicate records writen
+            facts(
+              path(s"${eavtConfig.hiveConfig.path}/*/*/*/*") ==> records(eavtReader, expected)
+            )
+            secondWriteResult must beLeft.like {
+              case FeatureSink.AttemptedWriteToCommitted(_) => true
+            }
+          }
+        )
+      }
+    }}.set(minTestsOk = 5)
+
+  def commitFailsIfSinkCommitted =
+    forAll { (vs: NonEmptyList[FeatureValue[Value]], eavtConfig: EavtSink.Config, dateTime: DateTime) =>  {
+      val expected = vs.map(EavtSink.toEavt(_, dateTime.getMillis)).list
+      withEnvironment(path(getClass.getResource("/").toString)) {
+        val sink = EavtSink(eavtConfig)
+        val writeResult = executesSuccessfully(sink.write(valuePipe(vs, dateTime)))
+
+        writeResult.fold(
+          e => failure("Unexpected write failure: " + e),
+          paths => {
+            executesSuccessfully(FeatureSink.commit(paths))
+            val secondCommitResult = executesSuccessfully(FeatureSink.commit(paths))
+
+            secondCommitResult must beLeft.like { case FeatureSink.AlreadyCommitted(_) => true }
+          }
         )
       }
     }}.set(minTestsOk = 5)

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/ScaldingDataSourceSpec.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/ScaldingDataSourceSpec.scala
@@ -32,7 +32,6 @@ import au.com.cba.omnia.thermometer.core.ThermometerSpec
 
 import commbank.coppersmith.api._
 import commbank.coppersmith.{DataSource, BoundFeatureSource}
-import ScaldingDataSource.Partitions
 
 import commbank.coppersmith.test.thrift.{Customer, Account}
 import commbank.coppersmith.Arbitraries._

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/ScaldingJobSpec.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/ScaldingJobSpec.scala
@@ -18,8 +18,6 @@ import org.joda.time.DateTime
 
 import com.twitter.scalding.{Config, Execution, TypedPipe}
 
-import org.apache.hadoop.fs.Path
-
 import org.scalacheck.Arbitrary
 import org.scalacheck.Gen.alphaStr
 import org.scalacheck.Prop.forAll
@@ -30,7 +28,8 @@ import au.com.cba.omnia.maestro.api._, Maestro._
 import au.com.cba.omnia.maestro.test.Records
 
 import au.com.cba.omnia.thermometer.core.Thermometer._
-import au.com.cba.omnia.thermometer.fact.PathFactoids.records
+import au.com.cba.omnia.thermometer.fact.Fact
+import au.com.cba.omnia.thermometer.fact.PathFactoids.{exists, records}
 import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 
 import commbank.coppersmith._, Feature._, FeatureBuilderSource.fromFS, Type._, Value._
@@ -47,6 +46,12 @@ class ScaldingJobSpec extends ThermometerHiveSpec with Records { def is = s2"""
 
     Running an aggregation feature set job
       writes all aggregation feature values $aggregationFeaturesJob ${tag("slow")}
+
+    Running a multi feature set job
+      writes feature values for seq sets $multiFeatureSetJobSeq ${tag("slow")}
+
+    Running a multi feature set job
+      writes feature values for par sets $multiFeatureSetJobPar ${tag("slow")}
   """
 
   {
@@ -66,8 +71,8 @@ class ScaldingJobSpec extends ThermometerHiveSpec with Records { def is = s2"""
   }
 
   def prepareData(
-    custAccts:   CustomerAccounts,
-    jobTime:     DateTime,
+    custAccts:  CustomerAccounts,
+    jobTime:    DateTime,
     eavtConfig: EavtSink.Config
   ): FeatureJobConfig[Account] = {
 
@@ -86,7 +91,7 @@ class ScaldingJobSpec extends ThermometerHiveSpec with Records { def is = s2"""
       _     <- Execution.guard(count == accounts.size, s"$count != ${accounts.size}")
     } yield JobFinished
 
-    executesSuccessfully(job, Map("hdfs-root" -> List(s"$dir/user")))
+    executesOk(job, Map("hdfs-root" -> List(s"$dir/user")))
 
     val accountDataSource = HiveParquetSource[Account, Nothing](
       path(s"$dir/user/account_db"),
@@ -113,10 +118,9 @@ class ScaldingJobSpec extends ThermometerHiveSpec with Records { def is = s2"""
       val expected = RegularFeatures.expectedFeatureValues(custAccts, jobTime)
 
       withEnvironment(path(getClass.getResource("/").toString)) {
-        executesSuccessfully(SimpleFeatureJob.generate((_: Config) => cfg, RegularFeatures), defaultArgs)
-        facts(
-          path(s"${eavtConfig.hiveConfig.path}/*/*/*/*") ==> records(eavtReader, expected)
-        )
+        executesOk(SimpleFeatureJob.generate((_: Config) => cfg, RegularFeatures), defaultArgs)
+        facts(successFlagsWritten(expected, jobTime): _*)
+        facts(path(s"${eavtConfig.hiveConfig.path}/*/*/*/*") ==> records(eavtReader, expected))
       }
     }}.set(minTestsOk = 5)
 
@@ -125,13 +129,57 @@ class ScaldingJobSpec extends ThermometerHiveSpec with Records { def is = s2"""
       val cfg = prepareData(custAccts, jobTime, eavtConfig)
       val expected = AggregationFeatures.expectedFeatureValues(custAccts, jobTime)
 
+
       withEnvironment(path(getClass.getResource("/").toString)) {
-        executesSuccessfully(SimpleFeatureJob.generate((_: Config) => cfg, AggregationFeatures), defaultArgs)
-        facts(
-          path(s"${eavtConfig.hiveConfig.path}/*/*/*/*") ==> records(eavtReader, expected)
-        )
+        executesOk(SimpleFeatureJob.generate((_: Config) => cfg, AggregationFeatures), defaultArgs)
+        facts(successFlagsWritten(expected, jobTime): _*)
+        facts(path(s"${eavtConfig.hiveConfig.path}/*/*/*/*") ==> records(eavtReader, expected))
       }
     }}.set(minTestsOk = 5)
+
+  def multiFeatureSetJobPar =
+    forAll { (custAccts: CustomerAccounts, jobTime: DateTime) => {
+      val cfg = prepareData(custAccts, jobTime, eavtConfig)
+      val expected =
+        RegularFeatures.expectedFeatureValues(custAccts, jobTime) ++
+          AggregationFeatures.expectedFeatureValues(custAccts, jobTime)
+
+      withEnvironment(path(getClass.getResource("/").toString)) {
+        val job = FeatureSetExecutions(
+          FeatureSetExecution((_: Config) => cfg, RegularFeatures),
+          FeatureSetExecution((_: Config) => cfg, AggregationFeatures)
+        )
+        executesOk(SimpleFeatureJob.generate(job), defaultArgs)
+        facts(successFlagsWritten(expected, jobTime): _*)
+        facts(path(s"${eavtConfig.hiveConfig.path}/*/*/*/*") ==> records(eavtReader, expected))
+      }
+    }}.set(minTestsOk = 5)
+
+  def multiFeatureSetJobSeq =
+    forAll { (custAccts: CustomerAccounts, jobTime: DateTime) => {
+      val cfg = prepareData(custAccts, jobTime, eavtConfig)
+      val expected =
+        RegularFeatures.expectedFeatureValues(custAccts, jobTime) ++
+          AggregationFeatures.expectedFeatureValues(custAccts, jobTime)
+
+      withEnvironment(path(getClass.getResource("/").toString)) {
+        val job = FeatureSetExecutions(
+          FeatureSetExecution((_: Config) => cfg, RegularFeatures)
+        ).andThen(
+          FeatureSetExecution((_: Config) => cfg, AggregationFeatures)
+        )
+        executesOk(SimpleFeatureJob.generate(job), defaultArgs)
+        facts(successFlagsWritten(expected, jobTime): _*)
+        facts(path(s"${eavtConfig.hiveConfig.path}/*/*/*/*") ==> records(eavtReader, expected))
+      }
+    }}.set(minTestsOk = 5)
+
+  private def successFlagsWritten(expectedValues: List[Eavt], dateTime: DateTime): Seq[Fact] = {
+    val expectedPartitions = expectedValues.map(EavtSink.partition.extract(_)).toSet.toSeq
+    expectedPartitions.map { case (year, month, day) =>
+      path(s"${eavtConfig.hiveConfig.path}/year=$year/month=$month/day=$day/_SUCCESS") ==> exists
+    }
+  }
 }
 
 object ScaldingJobSpec {

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.9.3"
+version in ThisBuild := "0.10.0"
 
 localVersionSettings


### PR DESCRIPTION
Also add support for fixed sink partitions (where partition information is passed in via config, not derived from source records), and avoiding writing to sinks that have already been written to.