### PR TITLE
Use writeThrough to avoid unnecessary MR stages

### DIFF
--- a/scalding/src/main/scala/commbank/coppersmith/scalding/FeatureSink.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/FeatureSink.scala
@@ -158,8 +158,8 @@ object HiveSupport {
         for {
                          // Use append semantics for now as an interim fix to address #97
                          // Check if this is still relevant once #137 is addressed
-          _           <- partitioned.writeExecution(sink).withSubConfig(createUniqueFilenames(_))
-          oPValues    <- partitioned.aggregate(Aggregator.toSet.composePrepare(_._1)).toOptionExecution
+          written     <- partitioned.writeThrough(sink).withSubConfig(createUniqueFilenames(_))
+          oPValues    <- written.aggregate(Aggregator.toSet.composePrepare(_._1)).toOptionExecution
           oPartitions  = oPValues.map(_.toSet.toList).toList.flatten.toNel.map(pValues =>
                            Partitions(conf.partition, pValues.head, pValues.tail: _*)
                          )

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.9.0"
+version in ThisBuild := "0.9.1"
 
 uniqueVersionSettings


### PR DESCRIPTION
This patch partially addresses a performance issue, where some feature sets were reading the input data twice. For example, `JoinFeaturesJob` from the user guide (aggregation over an inner join) was taking 5 MapReduce stages to execute on Hadoop, with the 1st and 3rd stages both scanning the two input tables in their entirety. With this patch, the same job takes only 3 MapReduce stages.

The theoretical minimum for that case would be 2 stages, so the current performance is significantly improved but still not optimal. The final stage appears to be necessary only for identifying the output partitions. But we are already discussing making the output partitions known up-front (instead of deriving partition keys from the feature values themselves), which if implemented would probably eliminate the 3rd MapReduce stage.