### PR TITLE
Make maestro dependencies lazy

### DIFF
--- a/core/src/main/scala/commbank/coppersmith/api/package.scala
+++ b/core/src/main/scala/commbank/coppersmith/api/package.scala
@@ -124,7 +124,7 @@ package object api {
   val Patterns = commbank.coppersmith.Patterns
 
   //Maestro dependencies below
-  val JobFinished =  au.com.cba.omnia.maestro.scalding.JobFinished
-  val HivePartition = au.com.cba.omnia.maestro.api.HivePartition
-  val Encode = au.com.cba.omnia.maestro.core.codec.Encode
+  lazy val JobFinished =  au.com.cba.omnia.maestro.scalding.JobFinished
+  lazy val HivePartition = au.com.cba.omnia.maestro.api.HivePartition
+  lazy val Encode = au.com.cba.omnia.maestro.core.codec.Encode
 }


### PR DESCRIPTION
Make maestro dependencies lazy so they only get initialised (and possibly cause errors) if they are needed