### PR TITLE
Log location of generated metadata when exporting

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -47,7 +47,7 @@ object build extends Build {
         ++ Seq(
         publishArtifact := false
       )
-    , aggregate = Seq(core, testProject, examples, scalding, tools)
+    , aggregate = Seq(core, testProject, examples, scalding, tools, plugin)
   )
 
   lazy val core = Project(

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.9.1"
+version in ThisBuild := "0.9.2"
 
 uniqueVersionSettings


### PR DESCRIPTION
Also include `plugin` sub-project in `all`, and tidy up some formatting.