### PR TITLE
Abstract EavtSink into TextSink and implement EavtTextSink

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,17 @@
 Change log
 ==========
 
+## 0.11.0
+Allow custom sinks.
+
+- Changed `EavtSink` to `EavtTextSink`.
+- Created a `TextSink` that takes a `Thrift` (describing the sink format),
+ and an implicit `FeatureValueEnc[T]` (that defines how to transform a
+ `FeatureValue` into the `Thrift` via `encode(FeatureValue => T)`).
+
+ ### Upgrading
+ References to `EavtSink` should be changed to `EavtTextSink`.
+
 ## 0.10.0
 Better support for running jobs with multiple feature sets. Also
 checks for absense of `_SUCCESS` file prior to writing features to sink,

--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -2,12 +2,12 @@ Change log
 ==========
 
 ## 0.11.0
-Allow custom sinks.
+Allow arbitrary feature value serialisation.
 
 - Changed `EavtSink` to `EavtTextSink`.
-- Created a `TextSink` that takes a `Thrift` (describing the sink format),
+- Created a `TextSink` that takes a `Thrift` struct (describing the sink format),
  and an implicit `FeatureValueEnc[T]` (that defines how to transform a
- `FeatureValue` into the `Thrift` via `encode(FeatureValue => T)`).
+ `FeatureValue` into the `Thrift` struct via `encode((FeatureValue, Time) => T)`).
 
  ### Upgrading
  References to `EavtSink` should be changed to `EavtTextSink`.

--- a/USERGUIDE.markdown
+++ b/USERGUIDE.markdown
@@ -177,8 +177,8 @@ Coppersmith currently supports the following source types:
 
 and one sink type:
 
-- `EavtTextSink`: a file in the format required for ingestion into the feature store (
-  text-encoded EAVT format)
+- `EavtTextSink`: writes EAVT records to a Hive-partitioned directory
+structure using delimited text encoding
 
 Here is an example of a job which materialises the feature set
 which we defined in the previous section:
@@ -289,8 +289,8 @@ object MultiPartitionSnippet {
 ### Alternate sinks
 
 If an output format different to `EavtTextSink` is required, then `TextSink`
-should be used. A `Thrift` defining the sink format is needed, as well as
-an implicit implementation of `FeatureValueEnc` for the `Thrift`.
+should be used. A `Thrift` struct defining the sink format is needed, as well as
+an implicit implementation of `FeatureValueEnc` for the `Thrift` struct.
 For example, this is a simple implementation where only the column names
 are different.
 
@@ -316,7 +316,6 @@ case class AlternativeSinkMovieFeaturesConfig(conf: Config) extends FeatureJobCo
           case Str(v) => v
         }).getOrElse(TextSink.NullValue)
 
-        // TODO: Does time format need to be configurable?
         val featureTime = new DateTime(time).toString("yyyy-MM-dd")
         FeatureEavt(fv.entity, fv.name, featureValue, featureTime)
     }

--- a/USERGUIDE.markdown
+++ b/USERGUIDE.markdown
@@ -177,7 +177,7 @@ Coppersmith currently supports the following source types:
 
 and one sink type:
 
-- `EavtSink`: a file in the format required for ingestion into the feature store (
+- `EavtTextSink`: a file in the format required for ingestion into the feature store (
   text-encoded EAVT format)
 
 Here is an example of a job which materialises the feature set
@@ -207,7 +207,7 @@ case class MovieFeaturesConfig(conf: Config) extends FeatureJobConfig[Movie] {
   val dbRoot         = new Path(conf.getArgs("db-root"))
   val tableName      = conf.getArgs("table-name")
 
-  val featureSink    = EavtSink.configure(dbPrefix, dbRoot, tableName)
+  val featureSink    = EavtTextSink.configure(dbPrefix, dbRoot, tableName)
 }
 
 object MovieFeaturesJob extends SimpleFeatureJob {
@@ -254,7 +254,7 @@ case class PartitionedMovieFeaturesConfig(conf: Config) extends FeatureJobConfig
   val dbPrefix              = conf.getArgs("db-prefix")
   val dbRoot                = new Path(conf.getArgs("db-root"))
   val tableName             = conf.getArgs("table-name")
-  val featureSink           = EavtSink.configure(dbPrefix, dbRoot, tableName)
+  val featureSink           = EavtTextSink.configure(dbPrefix, dbRoot, tableName)
 }
 
 object PartitionedMovieFeaturesJob extends SimpleFeatureJob {
@@ -285,6 +285,66 @@ object MultiPartitionSnippet {
   val movies     = HiveTextSource[Movie, Partition](new Path("data/movies"), partitions)
 }
 ```
+
+### Alternate sinks
+
+If an output format different to `EavtTextSink` is required, then `TextSink`
+should be used. A `Thrift` defining the sink format is needed, as well as
+an implicit implementation of `FeatureValueEnc` for the `Thrift`.
+For example, this is a simple implementation where only the column names
+are different.
+
+```scala
+package commbank.coppersmith.examples.userguide
+
+import org.apache.hadoop.fs.Path
+
+import com.twitter.scalding.Config
+
+import org.joda.time.DateTime
+
+import commbank.coppersmith.api._, scalding._, Coppersmith._
+import commbank.coppersmith.examples.thrift.{FeatureEavt, Movie}
+
+case class AlternativeSinkMovieFeaturesConfig(conf: Config) extends FeatureJobConfig[Movie] {
+  implicit object FeatureEavtEnc extends FeatureValueEnc[FeatureEavt] {
+    def encode(fvt: (FeatureValue[_], Time)): FeatureEavt = fvt match {
+      case (fv, time) =>
+        val featureValue = (fv.value match {
+          case Integral(v) => v.map(_.toString)
+          case Decimal(v) => v.map(_.toString)
+          case Str(v) => v
+        }).getOrElse(TextSink.NullValue)
+
+        // TODO: Does time format need to be configurable?
+        val featureTime = new DateTime(time).toString("yyyy-MM-dd")
+        FeatureEavt(fv.entity, fv.name, featureValue, featureTime)
+    }
+  }
+
+  val partitions     = Partitions.unpartitioned
+  val movies         = HiveTextSource[Movie, Nothing](new Path("data/movies"), partitions)
+
+  val featureSource  = From[Movie]().bind(from(movies))
+
+  val featureContext = ExplicitGenerationTime(new DateTime(2015, 1, 1, 0, 0))
+
+  val dbPrefix       = conf.getArgs("db-prefix")
+  val dbRoot         = new Path(conf.getArgs("db-root"))
+  val tableName      = conf.getArgs("table-name")
+
+  val sinkPartition  = DerivedSinkPartition[FeatureEavt, (String, String, String)](
+                         HivePartition.byDay(Fields[FeatureEavt].FeatureTime, "yyyy-MM-dd")
+                       )
+  val featureSink    = TextSink.configure(dbPrefix, dbRoot, tableName, sinkPartition)
+}
+
+object AlternativeSinkMovieFeaturesJob extends SimpleFeatureJob {
+  def job = generate(AlternativeSinkMovieFeaturesConfig(_), MovieFeatures)
+}
+```
+
+Note: When using `TextSink`, a `SinkPartition` is required.
 
 Intermediate
 ------------
@@ -589,7 +649,7 @@ trait CommonConfig {
   def conf: Config
 
   val featureContext = ExplicitGenerationTime(new DateTime(2015, 1, 1, 0, 0))
-  val featureSink    = EavtSink.configure("userguide", new Path("dev"), "movies")
+  val featureSink    = EavtTextSink.configure("userguide", new Path("dev"), "movies")
 }
 
 case class AggregationFeaturesConfig(conf: Config)
@@ -797,7 +857,7 @@ case class JoinFeaturesConfig(conf: Config) extends FeatureJobConfig[(Movie, Rat
   val ratings = HiveTextSource[Rating, Nothing](new Path("data/ratings"), Partitions.unpartitioned, "\t")
 
   val featureSource  = JoinFeatures.source.bind(join(movies, ratings))
-  val featureSink    = EavtSink.configure("userguide", new Path("dev"), "ratings")
+  val featureSink    = EavtTextSink.configure("userguide", new Path("dev"), "ratings")
   val featureContext = ExplicitGenerationTime(new DateTime(2015, 1, 1, 0, 0))
 }
 
@@ -847,7 +907,7 @@ case class LeftJoinFeaturesConfig(conf: Config) extends FeatureJobConfig[(Direct
   val directors = DirectorSourceConfig.dataSource
 
   val featureSource  = LeftJoinFeatures.source.bind(leftJoin(directors, movies))
-  val featureSink    = EavtSink.configure("userguide", new Path("dev"), "directors")
+  val featureSink    = EavtTextSink.configure("userguide", new Path("dev"), "directors")
   val featureContext = ExplicitGenerationTime(new DateTime(2015, 1, 1, 0, 0))
 }
 
@@ -908,7 +968,7 @@ case class MultiJoinFeaturesConfig(conf: Config) extends FeatureJobConfig[(Movie
                                                   Partitions.unpartitioned)
 
   val featureSource  = MultiJoinFeatures.source.bind(joinMulti((movies, ratings, users), MultiJoinFeatures.source))
-  val featureSink    = EavtSink.configure("userguide", new Path("dev"), "ratings")
+  val featureSink    = EavtTextSink.configure("userguide", new Path("dev"), "ratings")
   val featureContext = ExplicitGenerationTime(new DateTime(2015, 1, 1, 0, 0))
 }
 
@@ -1067,7 +1127,7 @@ case class ContextFeaturesConfig(conf: Config)
   // Note: Current date passed through as context param
   val featureSource  = ContextFeatures.source.bindWithContext(from(movies), date)
 
-  val featureSink    = EavtSink.configure("userguide", new Path("dev"), "movies")
+  val featureSink    = EavtTextSink.configure("userguide", new Path("dev"), "movies")
 
   val featureContext = ExplicitGenerationTime(date)
 }
@@ -1171,7 +1231,7 @@ case class DirectorFeaturesConfig(conf: Config) extends FeatureJobConfig[(Direct
 
   val featureSource  = source.bind(joinMulti((directorsSource, movies, ratings), source))
   val featureContext = ExplicitGenerationTime(new DateTime(2015, 1, 1, 0, 0))
-  val featureSink    = EavtSink.configure("userguide", new Path("dev"), "directors")
+  val featureSink    = EavtTextSink.configure("userguide", new Path("dev"), "directors")
 }
 
 object DirectorFeaturesJob extends SimpleFeatureJob {

--- a/core/src/main/scala/commbank/coppersmith/api/package.scala
+++ b/core/src/main/scala/commbank/coppersmith/api/package.scala
@@ -102,12 +102,17 @@ package object api {
   type PivotFeatureSet[S] = commbank.coppersmith.PivotFeatureSet[S]
   type ContextFeatureSource[S, C, FS <: FeatureSource[S, FS]] = commbank.coppersmith.ContextFeatureSource[S, C, FS]
   type DataSource[S, P[_]] = commbank.coppersmith.DataSource[S, P]
+  type FeatureValue[+V <: Value] = commbank.coppersmith.FeatureValue[V]
+  type Time = commbank.coppersmith.Feature.Time
 
   // Maestro dependencies below
   type JobStatus = au.com.cba.omnia.maestro.api.JobStatus
   type Fields[A] = au.com.cba.omnia.maestro.macros.FieldsMacro.Fields[A]
   type Encode[A] = au.com.cba.omnia.maestro.core.codec.Encode[A]
 
+  val Integral = commbank.coppersmith.Feature.Value.Integral
+  val Str = commbank.coppersmith.Feature.Value.Str
+  val Decimal = commbank.coppersmith.Feature.Value.Decimal
   val FeatureStub = commbank.coppersmith.FeatureStub
   val ExplicitGenerationTime = commbank.coppersmith.ExplicitGenerationTime
   val From = commbank.coppersmith.From

--- a/examples/src/main/scala/commbank/coppersmith/examples/Pivot.scala
+++ b/examples/src/main/scala/commbank/coppersmith/examples/Pivot.scala
@@ -14,7 +14,7 @@ case class PivotFeaturesConfig(conf: Config) extends FeatureJobConfig[Movie] {
   val partitions     = Partitions.unpartitioned
   val movies         = HiveTextSource[Movie, Nothing](new Path("data/movies"), partitions)
 
-  val featureSink    = EavtSink.configure("userguide", new Path("dev"), "movies")
+  val featureSink    = EavtTextSink.configure("userguide", new Path("dev"), "movies")
 
   val featureContext = ExplicitGenerationTime(new DateTime(2015, 1, 1, 0, 0))
 

--- a/examples/src/main/thrift/FeatureEavt.thrift
+++ b/examples/src/main/thrift/FeatureEavt.thrift
@@ -1,0 +1,22 @@
+#   Copyright 2014 Commonwealth Bank of Australia
+#
+#   Licensed under the Apache License, Version 2.0 (the "License");
+#   you may not use this file except in compliance with the License.
+#   You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+#   Unless required by applicable law or agreed to in writing, software
+#   distributed under the License is distributed on an "AS IS" BASIS,
+#   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#   See the License for the specific language governing permissions and
+#   limitations under the License.
+
+#@namespace scala commbank.coppersmith.examples.thrift
+
+struct FeatureEavt {
+  1  : string feature_entity
+  2  : string feature_name
+  3  : string feature_value
+  4  : string feature_time
+ }

--- a/project/FeatureJobGenerator.scala
+++ b/project/FeatureJobGenerator.scala
@@ -70,7 +70,7 @@ object FeatureJobGenerator {
           |
           |  val featureContext = ExplicitGenerationTime(new DateTime(2015, 1, 1, 0, 0))
           |
-          |  val featureSink    = EavtSink.configure("userguide", new Path("dev"), "$tableName")
+          |  val featureSink    = EavtTextSink.configure("userguide", new Path("dev"), "$tableName")
           |}
           |
           |object ${name}Job extends SimpleFeatureJob {

--- a/scalding/src/main/scala/commbank/coppersmith/api/scalding/package.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/api/scalding/package.scala
@@ -17,11 +17,11 @@ package commbank.coppersmith.api
 import com.twitter.scalding._
 import commbank.coppersmith.Lift
 
-
 package object scalding {
 
   type FeatureJobConfig[S] = commbank.coppersmith.scalding.FeatureJobConfig[S]
   type SimpleFeatureJob = commbank.coppersmith.scalding.SimpleFeatureJob
+  type FeatureValueEnc[T] = commbank.coppersmith.scalding.FeatureValueEnc[T]
 
   val FeatureSetExecutions = commbank.coppersmith.scalding.FeatureSetExecutions
   val FeatureSetExecution = commbank.coppersmith.scalding.FeatureSetExecution
@@ -31,7 +31,10 @@ package object scalding {
   val HiveTextSource = commbank.coppersmith.scalding.HiveTextSource
   val HiveParquetSource = commbank.coppersmith.scalding.HiveParquetSource
   val TypedPipeSource = commbank.coppersmith.scalding.TypedPipeSource
-  val EavtSink = commbank.coppersmith.scalding.EavtSink
+  val FixedSinkPartition = commbank.coppersmith.scalding.FixedSinkPartition
+  val DerivedSinkPartition = commbank.coppersmith.scalding.DerivedSinkPartition
+  val TextSink = commbank.coppersmith.scalding.TextSink
+  val EavtTextSink = commbank.coppersmith.scalding.EavtTextSink
 
   implicit val framework: Lift[TypedPipe] = commbank.coppersmith.scalding.lift.scalding
 }

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/EavtTextSink.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/EavtTextSink.scala
@@ -1,0 +1,49 @@
+package commbank.coppersmith.scalding
+
+import commbank.coppersmith.scalding.HiveSupport.{FailJob, DelimiterConflictStrategy}
+import org.apache.hadoop.fs.Path
+import org.joda.time.DateTime
+
+import au.com.cba.omnia.maestro.api._, Maestro._
+
+import commbank.coppersmith.{FeatureValue, Feature}, Feature._, Value._
+import commbank.coppersmith.thrift.Eavt
+
+/**
+  * Created by vaughaew on 4/05/2016.
+  */
+
+object EavtTextSink {
+  import TextSink._
+
+  val defaultPartition = DerivedSinkPartition[Eavt, (String, String, String)](
+    HivePartition.byDay(Fields[Eavt].Time, "yyyy-MM-dd")
+  )
+
+  type EavtTextSink = TextSink[Eavt]
+
+  implicit object EavtEnc extends FeatureValueEnc[Eavt] {
+    def encode(fvt: (FeatureValue[_], Time)): Eavt = fvt match {
+      case (fv, time) =>
+        val featureValue = (fv.value match {
+          case Integral(v) => v.map(_.toString)
+          case Decimal(v) => v.map(_.toString)
+          case Str(v) => v
+        }).getOrElse(TextSink.NullValue)
+
+        // TODO: Does time format need to be configurable?
+        val featureTime = new DateTime(time).toString("yyyy-MM-dd")
+        Eavt(fv.entity, fv.name, featureValue, featureTime)
+    }
+  }
+
+  def configure(dbPrefix:  String,
+                 dbRoot:    Path,
+                 tableName: TableName,
+                 partition: SinkPartition[Eavt] = defaultPartition,
+                 group:     Option[String] = None,
+                 dcs:       DelimiterConflictStrategy[Eavt] = FailJob[Eavt]()): EavtTextSink = {
+    TextSink.configure(dbPrefix, dbRoot, tableName, partition, group, dcs)
+  }
+
+}

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/EavtTextSink.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/EavtTextSink.scala
@@ -1,3 +1,17 @@
+//
+// Copyright 2016 Commonwealth Bank of Australia
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//        http://www.apache.org/licenses/LICENSE-2.0
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
 package commbank.coppersmith.scalding
 
 import commbank.coppersmith.scalding.HiveSupport.{FailJob, DelimiterConflictStrategy}
@@ -8,10 +22,6 @@ import au.com.cba.omnia.maestro.api._, Maestro._
 
 import commbank.coppersmith.{FeatureValue, Feature}, Feature._, Value._
 import commbank.coppersmith.thrift.Eavt
-
-/**
-  * Created by vaughaew on 4/05/2016.
-  */
 
 object EavtTextSink {
   import TextSink._

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/FeatureSink.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/FeatureSink.scala
@@ -16,6 +16,7 @@ package commbank.coppersmith.scalding
 
 import com.twitter.scalding.typed.TypedPipe
 import com.twitter.scalding.{Execution, TupleSetter}
+import com.twitter.util.Encoder
 
 import org.apache.hadoop.fs.Path
 
@@ -101,10 +102,7 @@ final case class DerivedSinkPartition[T, PP : PathComponents : TupleSetter](
   def tupleSetter = implicitly
 }
 
-trait Encode[D, E] {
-  def encode(d: D): E
-}
-trait FeatureValueEnc[T] extends Encode[(FeatureValue[_], Time), T] {
+trait FeatureValueEnc[T] extends Encoder[(FeatureValue[_], Time), T] {
   def encode(fvt: (FeatureValue[_], Time)): T
 }
 

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/TestEavtTextSink.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/TestEavtTextSink.scala
@@ -1,13 +1,23 @@
+//
+// Copyright 2016 Commonwealth Bank of Australia
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//        http://www.apache.org/licenses/LICENSE-2.0
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
 package commbank.coppersmith.scalding
 
 import org.joda.time.DateTime
 
 import commbank.coppersmith.api._, Coppersmith._
 import commbank.coppersmith.thrift.Eavt
-
-/**
-  * Created by vaughaew on 4/05/2016.
-  */
 
 object TestEavtTextSink {
 

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/TestEavtTextSink.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/TestEavtTextSink.scala
@@ -1,0 +1,32 @@
+package commbank.coppersmith.scalding
+
+import org.joda.time.DateTime
+
+import commbank.coppersmith.api._, Coppersmith._
+import commbank.coppersmith.thrift.Eavt
+
+/**
+  * Created by vaughaew on 4/05/2016.
+  */
+
+object TestEavtTextSink {
+
+  val defaultPartition = DerivedSinkPartition[Eavt, (String, String, String)](
+    HivePartition.byDay(Fields[Eavt].Time, "yyyy-MM-dd")
+  )
+
+  implicit object EavtEnc extends FeatureValueEnc[Eavt] {
+    def encode(fvt: (FeatureValue[_], Time)): Eavt = fvt match {
+      case (fv, time) =>
+        val featureValue = (fv.value match {
+          case Integral(v) => v.map(_.toString)
+          case Decimal(v) => v.map(_.toString)
+          case Str(v) => v
+        }).getOrElse(TextSink.NullValue)
+
+        val featureTime = new DateTime(time).toString("yyyy-MM-dd")
+        Eavt(fv.entity, fv.name, featureValue, featureTime)
+    }
+  }
+
+}

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/TextSinkSpec.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/TextSinkSpec.scala
@@ -30,7 +30,7 @@ import au.com.cba.omnia.thermometer.core.Thermometer._
 import au.com.cba.omnia.thermometer.fact.PathFactoids.{exists, missing, records}
 import au.com.cba.omnia.thermometer.hive.ThermometerHiveSpec
 
-import commbank.coppersmith._, Arbitraries._, commbank.coppersmith.Feature.Value
+import commbank.coppersmith._, Arbitraries._, Feature.Value
 import TestEavtTextSink.EavtEnc
 import ScaldingArbitraries._
 import thrift.Eavt

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.10.1"
+version in ThisBuild := "0.11.0"
 
 localVersionSettings


### PR DESCRIPTION
Allows definition of custom sinks using `Thrift` structs other than `Eavt`.