### PR TITLE
Improve Userguide examples

### DIFF
--- a/USERGUIDE.markdown
+++ b/USERGUIDE.markdown
@@ -137,8 +137,8 @@ import commbank.coppersmith.api._
 import commbank.coppersmith.examples.thrift.User
 
 object UserFeatures extends BasicFeatureSet[User] {
-  val namespace              = "userguide.examples"
-  def entity(user: User)     = user.id
+  val namespace          = "userguide.examples"
+  def entity(user: User) = user.id
 
   val userAge = basicFeature[Integral](
     "USER_AGE", "Age of user in years", Continuous,
@@ -149,8 +149,8 @@ object UserFeatures extends BasicFeatureSet[User] {
 }
 ```
 
-Note that, as opposed to above, returning `None` as part of `basicFeature` will
-generate a feature with a value of `null`.
+Note that, as opposed to above, returning `None` from the function
+passed to `basicFeature` will generate a feature with a value of `null`.
 
 ### Execution: the `SimpleFeatureJob` class
 
@@ -392,11 +392,12 @@ object Implicits {
 
     def safeReleaseDate: Option[Datestamp] =
       movie.releaseDate.flatMap(parse(_).right.toOption)
-    def releaseYear:     Option[Int]      = safeReleaseDate.map(_.year)
-    def isComedy:        Boolean          = movie.comedy == 1
-    def isFantasy:       Boolean          = movie.fantasy == 1
-    def isAction:        Boolean          = movie.action == 1
-    def isScifi:         Boolean          = movie.scifi == 1
+
+    def releaseYear: Option[Int] = safeReleaseDate.map(_.year)
+    def isComedy:    Boolean     = movie.comedy == 1
+    def isFantasy:   Boolean     = movie.fantasy == 1
+    def isAction:    Boolean     = movie.action == 1
+    def isScifi:     Boolean     = movie.scifi == 1
 
     def ageAt(date: Datestamp): Option[Int] = safeReleaseDate.map(_.difference(date).years)
   }
@@ -956,8 +957,8 @@ import commbank.coppersmith.examples.thrift.Movie
 import Implicits.RichMovie
 
 object SourceViewFeatures extends FeatureSetWithTime[Movie] {
-  val namespace              = "userguide.examples"
-  def entity(movie: Movie)   = movie.id
+  val namespace            = "userguide.examples"
+  def entity(movie: Movie) = movie.id
 
   val source  = From[Movie]()
   val builder = source.featureSetBuilder(namespace, entity)

--- a/examples/src/main/thrift/Movie.thrift
+++ b/examples/src/main/thrift/Movie.thrift
@@ -17,7 +17,7 @@
 struct Movie {
   1 	: string  id
   2 	: string  title
-  3 	: string  release_date
+  3 	: optional string  release_date
   4 	: optional string  video_release_date
   5 	: optional string  imdb_url
   6 	: i32     unknown

--- a/examples/src/main/thrift/User.thrift
+++ b/examples/src/main/thrift/User.thrift
@@ -16,7 +16,7 @@
 
 struct User {
   1  : string id
-  2  : string age
+  2  : i32    age
   3  : string gender
   4  : string occupation
   5  : string zipcode

--- a/examples/src/test/scala/commbank/coppersmith/examples/userguide/Arbitraries.scala
+++ b/examples/src/test/scala/commbank/coppersmith/examples/userguide/Arbitraries.scala
@@ -19,7 +19,7 @@ import java.text.SimpleDateFormat
 
 import org.scalacheck.{Arbitrary, Gen}, Arbitrary.arbitrary
 
-import commbank.coppersmith.examples.thrift.{Movie, Rating}
+import commbank.coppersmith.examples.thrift.{Movie, Rating, User}
 
 object UserGuideArbitraries {
   // Override the default implicit Arbitrary[String] (brought into scope by Arbitrary.arbString)
@@ -35,7 +35,7 @@ object UserGuideArbitraries {
     for {
       id               <- genMovieId
       title            <- arbitrary[String]
-      releaseDate      <- arbitrary[Date].map(formatDate)
+      releaseDate      <- arbitrary[Option[Date]].map(_.map(formatDate))
       videoReleaseDate <- arbitrary[Option[Date]].map(_.map(formatDate))
       url              <- arbitrary[Option[String]]
       genres           <- Gen.containerOfN[List, Int](19, Gen.oneOf(0, 1))  // each genre flag is either 0 or 1
@@ -55,5 +55,15 @@ object UserGuideArbitraries {
       rating    <- Gen.oneOf(1, 2, 3, 4, 5)
       timestamp <- arbitrary[Date].map(d => (d.getTime/1000).toString)  // seconds since epoch
     } yield Rating(userId, movieId, rating, timestamp)
+  }
+
+  implicit def arbUser: Arbitrary[User] = Arbitrary {
+    for {
+      id         <- genUserId
+      age        <- arbitrary[Int]
+      gender     <- Gen.oneOf("M", "F")
+      occupation <- arbitrary[String]
+      zipcode    <- arbitrary[String]
+    } yield User(id, age, gender, occupation, zipcode)
   }
 }

--- a/examples/src/test/scala/commbank/coppersmith/examples/userguide/DirectorFeaturesSpec.scala
+++ b/examples/src/test/scala/commbank/coppersmith/examples/userguide/DirectorFeaturesSpec.scala
@@ -35,7 +35,7 @@ object DirectorFeaturesSpec extends ThermometerHiveSpec {
     implicit def arbSafeHiveTextString: Arbitrary[String] = Arbitrary(Gen.identifier)
 
     def movie(id: String, title: String) =
-      Movie(id, title, "Jan-01-1995", None, None, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
+      Movie(id, title, Some("Jan-01-1995"), None, None, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0)
 
     def rating(movie: String, rating: Int) =
       Gen.resultOf(Rating.apply _).sample.get.copy(movieId = movie, rating = rating)

--- a/examples/src/test/scala/commbank/coppersmith/examples/userguide/DistinctFeaturesSpec.scala
+++ b/examples/src/test/scala/commbank/coppersmith/examples/userguide/DistinctFeaturesSpec.scala
@@ -26,26 +26,26 @@ import au.com.cba.omnia.maestro.api._, Maestro._
 
 import commbank.coppersmith.api.JobFinished
 import commbank.coppersmith.api._
-import commbank.coppersmith.examples.thrift.Movie
+import commbank.coppersmith.examples.thrift.User
 
-import UserGuideArbitraries.arbMovie
+import UserGuideArbitraries.arbUser
 
 object DistinctFeaturesSpec extends ThermometerHiveSpec { def is = s2"""
   DistinctFeaturesJob must return expected values  $test  ${tag("slow")}
 """
-  def test = forAll { (movies: Seq[Movie]) => {
-    writeRecords[Movie](s"$dir/user/data/movies/data.txt", movies, "|")
-    val expectedLength = movies.groupBy(_.id).keys.size
+  def test = forAll { (users: Seq[User]) => {
+    writeRecords[User](s"$dir/user/data/users/data.txt", users, "|")
+    val expectedLength = users.groupBy(_.id).keys.size
 
     val job = for {
       // Clear previous test data
-      _      <- Execution.fromHdfs(Hdfs.delete(path(s"$dir/user/dev/ratings"), true))
-      result <- DistinctMovieFeaturesJob.job
+      _      <- Execution.fromHdfs(Hdfs.delete(path(s"$dir/user/dev/users"), true))
+      result <- DistinctUserFeaturesJob.job
     } yield result
 
     executesSuccessfully(job) must_== JobFinished
 
-    val outPath = s"$dir/user/dev/ratings/year=2015/month=01/day=01/*"
+    val outPath = s"$dir/user/dev/users/year=2015/month=01/day=01/*"
     expectations { context =>
       context.lines(new Path(outPath)).toSet.size must_== expectedLength
     }


### PR DESCRIPTION
Simplifying the early userguide examples by changing MOVIE_RELEASE_YEAR features to USER_AGE features, removing the need for date parsing.

Moved the alternate sink example to the advanced section, as it's an advanced feature.