### PR TITLE
Integral as Nominal feature type

### DIFF
--- a/core/src/main/scala/commbank/coppersmith/Feature.scala
+++ b/core/src/main/scala/commbank/coppersmith/Feature.scala
@@ -109,6 +109,7 @@ object Feature {
     def valueTag: TypeTag[V] = implicitly
   }
   implicit object NominalStr              extends Conforms[Type.Nominal.type,    Value.Str]
+  implicit object OrdinalStr              extends Conforms[Type.Ordinal.type,    Value.Str]
 
   implicit object OrdinalDecimal          extends Conforms[Type.Ordinal.type,    Value.Decimal]
   implicit object ContinuousDecimal       extends Conforms[Type.Continuous.type, Value.Decimal]
@@ -116,9 +117,9 @@ object Feature {
   implicit object OrdinalFloatingPoint    extends Conforms[Type.Ordinal.type,    Value.FloatingPoint]
   implicit object ContinuousFloatingPoint extends Conforms[Type.Continuous.type, Value.FloatingPoint]
 
+  implicit object NominalIntegral         extends Conforms[Type.Nominal.type,    Value.Integral]
   implicit object OrdinalIntegral         extends Conforms[Type.Ordinal.type,    Value.Integral]
   implicit object ContinuousIntegral      extends Conforms[Type.Continuous.type, Value.Integral]
-
   implicit object DiscreteIntegral        extends Conforms[Type.Discrete.type,   Value.Integral]
 
   implicit object InstantDate             extends Conforms[Type.Instant.type,    Value.Date]

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.20.0"
+version in ThisBuild := "0.20.1"
 
 localVersionSettings


### PR DESCRIPTION
* Integral values can be expressed as a `Nominal` feature type.
* `Instant` feature type added to user guide.
* abs site link added to the user guide for further information on feature types.
* `"Engineer"` changed to `"engineer"` in user guide since user occupations are in all lower case.
* `occupationCode` feature added to show an example of an integral `Nominal` feature type.