### PR TITLE
Remove existential type from sink codec

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,17 @@
 Change log
 ==========
 
+## 0.19.0
+Change type used in feature sink codec from `FeatureValue[_]` to
+`FeatureValue[Value]`. In practice this shouldn't affect users of
+coppersmith, except where values are being non-exhaustively matched on
+(which could occur with the introduction of the `Bool` type in
+`0.17.0`, and the `Date` and `Time` types in `0.15.0`).
+
+### Upgrading
+ - If code produces `match may not be exhaustive` warnings at
+   compile-time, add missing cases.
+
 ## 0.18.0
 Range metadata arguments added to Feature building classes, allowing ranges
 to be easily specified in Feature Sets.

--- a/USERGUIDE.markdown
+++ b/USERGUIDE.markdown
@@ -1226,13 +1226,14 @@ import commbank.coppersmith.examples.thrift.{FeatureEavt, User}
 
 case class AlternativeSinkUserFeaturesConfig(conf: Config) extends FeatureJobConfig[User] {
   implicit object FeatureEavtEnc extends FeatureValueEnc[FeatureEavt] {
-    def encode(fvt: (FeatureValue[_], FeatureTime)): FeatureEavt = fvt match {
+    def encode(fvt: (FeatureValue[Value], FeatureTime)): FeatureEavt = fvt match {
       case (fv, time) =>
         val featureValue = (fv.value match {
           case Integral(v)      => v.map(_.toString)
           case Decimal(v)       => v.map(_.toString)
           case FloatingPoint(v) => v.map(_.toString)
           case Str(v)           => v
+          case Bool(v)          => v.map(_.toString)
           case Date(v)          => v.map(_.toString)
           case Time(v)          => v.map(_.toString)
         }).getOrElse(HiveTextSink.NullValue)

--- a/core/src/main/scala/commbank/coppersmith/Feature.scala
+++ b/core/src/main/scala/commbank/coppersmith/Feature.scala
@@ -215,13 +215,13 @@ abstract class Feature[S, +V <: Value](val metadata: Metadata[S, V]) {
 }
 
 case class FeatureValue[+V <: Value](
-  entity:  EntityId,
-  name:    Name,
-  value:   V
+  entity: EntityId,
+  name:   Name,
+  value:  V
 )
 
 object FeatureValue {
-  implicit class AsEavt[V <: Value](fv: FeatureValue[V]) {
-    def asEavt(time: FeatureTime): (EntityId, Name, V, FeatureTime) = (fv.entity, fv.name, fv.value, time)
+  implicit class AsEavt(fv: FeatureValue[Value]) {
+    def asEavt(time: FeatureTime): (EntityId, Name, Value, FeatureTime) = (fv.entity, fv.name, fv.value, time)
   }
 }

--- a/core/src/main/scala/commbank/coppersmith/api/package.scala
+++ b/core/src/main/scala/commbank/coppersmith/api/package.scala
@@ -50,6 +50,7 @@ package object api extends GeneratedJoinTypeInstances with SourceBinderInstances
   type DataSource[S, P[_]] = commbank.coppersmith.DataSource[S, P]
   type FeatureValue[+V <: Value] = commbank.coppersmith.FeatureValue[V]
   type FeatureTime = commbank.coppersmith.Feature.FeatureTime
+  type Value = commbank.coppersmith.Feature.Value
 
   // Maestro dependencies below
   type JobStatus = au.com.cba.omnia.maestro.api.JobStatus

--- a/examples/src/main/scala/commbank/coppersmith/examples/FlatFeatureSink.scala
+++ b/examples/src/main/scala/commbank/coppersmith/examples/FlatFeatureSink.scala
@@ -19,20 +19,24 @@ import org.apache.hadoop.fs.Path
 import com.twitter.scalding.typed.TypedPipe
 import com.twitter.scalding.TypedTsv
 
-import commbank.coppersmith.Feature.FeatureTime
-import commbank.coppersmith.Feature.Value.{Decimal, Integral, Str}
+import commbank.coppersmith.Feature.{FeatureTime, Value}
+import commbank.coppersmith.Feature.Value._
 import commbank.coppersmith.FeatureValue
 import commbank.coppersmith.scalding.FeatureSink, FeatureSink.WriteResult
 
 case class FlatFeatureSink(output: String) extends FeatureSink {
   def path = new Path(output)
-  override def write(features: TypedPipe[(FeatureValue[_], FeatureTime)]): WriteResult = {
+  override def write(features: TypedPipe[(FeatureValue[Value], FeatureTime)]): WriteResult = {
 
     val featurePipe = features.map { case (fv, t) =>
       val featureValue = (fv.value match {
-        case Integral(v) => v.map(_.toString)
-        case Decimal(v)  => v.map(_.toString)
-        case Str(v)      => v
+        case Integral(v)      => v.map(_.toString)
+        case Decimal(v)       => v.map(_.toString)
+        case FloatingPoint(v) => v.map(_.toString)
+        case Str(v)           => v
+        case Bool(v)          => v.map(_.toString)
+        case Date(v)          => v.map(_.toString)
+        case Time(v)          => v.map(_.toString)
       }).getOrElse("")
       s"${fv.entity}|${fv.name}|${featureValue}"
     }

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/EavtText.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/EavtText.scala
@@ -27,9 +27,9 @@ object EavtText {
   )
 
   implicit object EavtEnc extends FeatureValueEnc[Eavt] {
-    def encode(fvt: (FeatureValue[_], FeatureTime)): Eavt = fvt match {
+    def encode(fvt: (FeatureValue[Value], FeatureTime)): Eavt = fvt match {
       case (fv, time) =>
-        val featureValue = (fv.value.asInstanceOf[Value] match {  // asInstanceOf enforces exhaustiveness.
+        val featureValue = (fv.value match {
           case Integral(v) => v.map(_.toString)
           case Decimal(v) => v.map(_.toString)
           case FloatingPoint(v) => v.map(_.toString)

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/FeatureJob.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/FeatureJob.scala
@@ -138,7 +138,7 @@ object FeatureSetExecution {
   import SimpleFeatureJob.writeErrorFailure
   private def generateFeatures[S](
     cfg:       Config => FeatureJobConfig[S],
-    transform: (TypedPipe[S], FeatureContext) => TypedPipe[(FeatureValue[_], FeatureTime)]
+    transform: (TypedPipe[S], FeatureContext) => TypedPipe[(FeatureValue[Value], FeatureTime)]
   ): Execution[Set[Path]] = {
     for {
       conf   <- Execution.getConfig.map(cfg)
@@ -152,7 +152,7 @@ object FeatureSetExecution {
 
   private def generateOneToMany[S](
     features: FeatureSetWithTime[S]
-  )(input: TypedPipe[S], ctx: FeatureContext): TypedPipe[(FeatureValue[_], FeatureTime)] = {
+  )(input: TypedPipe[S], ctx: FeatureContext): TypedPipe[(FeatureValue[Value], FeatureTime)] = {
     input.flatMap { s =>
       val time = features.time(s, ctx)
       features.generate(s).map(fv => (fv, time))
@@ -161,7 +161,7 @@ object FeatureSetExecution {
 
   private def generateAggregate[S](
     features: AggregationFeatureSet[S]
-  )(input: TypedPipe[S], ctx: FeatureContext): TypedPipe[(FeatureValue[_], FeatureTime)] = {
+  )(input: TypedPipe[S], ctx: FeatureContext): TypedPipe[(FeatureValue[Value], FeatureTime)] = {
     val grouped: Grouped[EntityId, S] = input.groupBy(s => features.entity(s))
     val (joinedAggregator, unjoiner) = join(features.aggregationFeatures.toList.map(serialisable(_)))
     grouped.aggregate(joinedAggregator).toTypedPipe.flatMap { case (e, v) =>

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/FeatureSink.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/FeatureSink.scala
@@ -43,7 +43,7 @@ trait FeatureSink {
     * Persist feature values, returning the list of paths written (for committing at the
     * end of the job) or an error if trying to write to a path that is already committed
     */
-  def write(features: TypedPipe[(FeatureValue[_], FeatureTime)]): WriteResult
+  def write(features: TypedPipe[(FeatureValue[Value], FeatureTime)]): WriteResult
 }
 
 object FeatureSink {
@@ -113,8 +113,8 @@ final case class DerivedSinkPartition[T, PP : PathComponents : TupleSetter](
   def tupleSetter = implicitly
 }
 
-trait FeatureValueEnc[T] extends Encoder[(FeatureValue[_], FeatureTime), T] {
-  def encode(fvt: (FeatureValue[_], FeatureTime)): T
+trait FeatureValueEnc[T] extends Encoder[(FeatureValue[Value], FeatureTime), T] {
+  def encode(fvt: (FeatureValue[Value], FeatureTime)): T
 }
 
 object HiveTextSink {
@@ -135,7 +135,7 @@ case class HiveTextSink[
   delimiter: String = HiveTextSink.Delimiter,
   dcs:       DelimiterConflictStrategy[T] = FailJob[T]()
 ) extends FeatureSink {
-  def write(features: TypedPipe[(FeatureValue[_], FeatureTime)]) = {
+  def write(features: TypedPipe[(FeatureValue[Value], FeatureTime)]) = {
     val textPipe = features.map(implicitly[FeatureValueEnc[T]].encode)
 
     val hiveConfig =

--- a/scalding/src/main/scala/commbank/coppersmith/scalding/HiveParquetSink.scala
+++ b/scalding/src/main/scala/commbank/coppersmith/scalding/HiveParquetSink.scala
@@ -31,7 +31,7 @@ case class HiveParquetSink[T <: ThriftStruct : Manifest : FeatureValueEnc, P : T
   table:         HiveTable[T, (P, T)],
   partitionPath: Path
 ) extends FeatureSink {
-  def write(features: TypedPipe[(FeatureValue[_], FeatureTime)]): FeatureSink.WriteResult = {
+  def write(features: TypedPipe[(FeatureValue[Value], FeatureTime)]): FeatureSink.WriteResult = {
     FeatureSink.isCommitted(partitionPath).flatMap(committed =>
       if (committed) {
         Execution.from(Left(AttemptedWriteToCommitted(partitionPath)))

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/ScaldingSinkSpec.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/ScaldingSinkSpec.scala
@@ -273,9 +273,9 @@ class HiveParquetSinkSpec extends ScaldingSinkSpec[HiveParquetSink[Eavt, (String
 
   implicit def eavtEnc = new FeatureValueEnc[Eavt] {
     import Value._
-    def encode(fvt: (FeatureValue[_], Long)): Eavt = fvt match {
+    def encode(fvt: (FeatureValue[Value], Long)): Eavt = fvt match {
       case (fv, time) =>
-        val featureValue = (fv.value.asInstanceOf[Value] match {
+        val featureValue = (fv.value match {
           case Integral(v) => v.map(_.toString)
           case Decimal(v) => v.map(_.toString)
           case FloatingPoint(v) => v.map(_.toString)

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.18.0"
+version in ThisBuild := "0.19.0"
 
 localVersionSettings


### PR DESCRIPTION
Allows exhaustiveness checking in match statements. Also fix places where match wasn't exhaustive.