### PR TITLE
Stop pulling in coppersmith dependencies in the coppersmith plugin

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,14 @@
 Change log
 ==========
 
+## 0.21.0
+The coppersmith plugin no longer pulls in coppersmith dependencies, so
+that dependency clashes are easier to manage.
+
+### Upgrading
+  - Add `coppersmith-core`, `coppersmith-scalding` and `coppersmith-tools`
+    dependencies to `build.sbt` (see [user guide](USERGUIDE.markdown) for more details).
+
 ## 0.20.0
 Use the version of shapeless specified by uniform, instead of requiring
 shapeless version `2.2.5`. This is potentially a breaking change for users

--- a/USERGUIDE.markdown
+++ b/USERGUIDE.markdown
@@ -54,9 +54,14 @@ Add the coppersmith plugin to your SBT configuration. That is, inside
 
     addSbtPlugin("au.com.cba.omnia" %% "coppersmith-plugin" % "<coppersmith-version>")
 
+, and inside `build.sbt`,
+
+    libraryDependencies ++= Seq("au.com.cba.omnia" %% "coppersmith-core"     % "<coppersmith-version>",
+                                "au.com.cba.omnia" %% "coppersmith-scalding" % "<coppersmith-version>",
+                                "au.com.cba.omnia" %% "coppersmith-tools"    % "<coppersmith-version>")
+
 , where `<coppersmith-version>` is replaced with the version number of
-coppersmith you want to use. The plugin adds the appropriate coppersmith versions
-to your build and enables the publishing of feature metadata.
+coppersmith you want to use. The plugin enables the publishing of feature metadata.
 
 
 ### The `Feature` class

--- a/plugin/README.markdown
+++ b/plugin/README.markdown
@@ -1,16 +1,20 @@
 Coppersmith Plugin
 ==================
 
-The coppersmith plugin automatically adds coppersmith to a project's library dependencies
-and generates metadata as a published artifact.
+The coppersmith plugin generates metadata as a published artifact.
 
 To install the plugin, add the following to `project/plugins.sbt`:
 
-```scala
-addSbtPlugin("au.com.cba.omnia" %% "coppersmith-plugin" % "<coppersmith-version>")
-```
+    addSbtPlugin("au.com.cba.omnia" %% "coppersmith-plugin" % "<coppersmith-version>")
 
-where `coppersmith-version` is the version of coppersmith you want to use.
+and add the following to `build.sbt`:
+
+    libraryDependencies ++= Seq("au.com.cba.omnia" %% "coppersmith-core"     % "<coppersmith-version>",
+                                "au.com.cba.omnia" %% "coppersmith-scalding" % "<coppersmith-version>",
+                                "au.com.cba.omnia" %% "coppersmith-tools"    % "<coppersmith-version>")
+
+, where `<coppersmith-version>` is replaced with the version number of
+coppersmith you want to use.
 
 From there, ```metadata:export``` will generate a metadata JSON file, and the
 artifacts published by `publishLocal` and `publish` will include the metadata

--- a/plugin/src/main/scala/commbank/coppersmith/plugin/CoppersmithPlugin.scala
+++ b/plugin/src/main/scala/commbank/coppersmith/plugin/CoppersmithPlugin.scala
@@ -27,11 +27,6 @@ object CoppersmithPlugin extends AutoPlugin {
   import autoImport._
 
   lazy val baseMetadataSettings: Seq[sbt.Def.Setting[_]] = Seq(
-    libraryDependencies ++= Seq(
-      "au.com.cba.omnia" %% "coppersmith-core" %     VersionInfo.version,
-      "au.com.cba.omnia" %% "coppersmith-scalding" % VersionInfo.version,
-      "au.com.cba.omnia" %% "coppersmith-tools" %    VersionInfo.version
-    ),
     scalaVersion := "2.11.8"
   ) ++ Seq(
     artifacts += Artifact(name.value, "metadata", "json"),
@@ -49,6 +44,15 @@ object CoppersmithPlugin extends AutoPlugin {
         version,
         streams
       ).map { (deps, cp, tgt, v, strms) =>
+        val artifacts = for {
+          af       <- cp
+          artifact <- af.get(artifact.key)
+        } yield artifact.name
+
+        if (!(Set("coppersmith-core_2.11", "coppersmith-scalding_2.11", "coppersmith-tools_2.11") forall (artifacts contains)))
+          sys.error("The Coppersmith plugin requires coppersmith-core, coppersmith-scalding and coppersmith-tools. " +
+            "Please add these as dependencies in your build.sbt.")
+
         val classpathString = cp.files.mkString(":")
         val res = Process(
           Seq("java", "-cp", classpathString, "commbank.coppersmith.tools.MetadataMain", "--json", "")

--- a/plugin/src/sbt-test/coppersmith-plugin/no-dependencies/build.sbt
+++ b/plugin/src/sbt-test/coppersmith-plugin/no-dependencies/build.sbt
@@ -19,16 +19,3 @@ scalaVersion := "2.11.8"
 resolvers ++= Seq(
   "commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local",
   "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/")
-
-lazy val all = Project(id = "all", base = file("."))
-
-lazy val sub = Project(id = "sub", base = file("subproject")).settings(version := "0.1-DEMO", {
-  val pluginVersion = System.getProperty("plugin.version")
-  if (pluginVersion == null)
-    throw new RuntimeException("""|The system property 'plugin.version' is not defined.
-                                  |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-  else libraryDependencies ++= Seq("au.com.cba.omnia" %% "coppersmith-core"     % pluginVersion,
-                                   "au.com.cba.omnia" %% "coppersmith-scalding" % pluginVersion,
-                                   "au.com.cba.omnia" %% "coppersmith-tools"    % pluginVersion
-  )
-})

--- a/plugin/src/sbt-test/coppersmith-plugin/no-dependencies/project/plugins.sbt
+++ b/plugin/src/sbt-test/coppersmith-plugin/no-dependencies/project/plugins.sbt
@@ -12,23 +12,10 @@
 //    limitations under the License.
 //
 
-version := "0.1-DEMO"
-
-scalaVersion := "2.11.8"
-
-resolvers ++= Seq(
-  "commbank-releases" at "http://commbank.artifactoryonline.com/commbank/ext-releases-local",
-  "cloudera" at "https://repository.cloudera.com/artifactory/cloudera-repos/")
-
-lazy val all = Project(id = "all", base = file("."))
-
-lazy val sub = Project(id = "sub", base = file("subproject")).settings(version := "0.1-DEMO", {
+{
   val pluginVersion = System.getProperty("plugin.version")
-  if (pluginVersion == null)
+  if(pluginVersion == null)
     throw new RuntimeException("""|The system property 'plugin.version' is not defined.
                                   |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-  else libraryDependencies ++= Seq("au.com.cba.omnia" %% "coppersmith-core"     % pluginVersion,
-                                   "au.com.cba.omnia" %% "coppersmith-scalding" % pluginVersion,
-                                   "au.com.cba.omnia" %% "coppersmith-tools"    % pluginVersion
-  )
-})
+  else addSbtPlugin("au.com.cba.omnia" %% "coppersmith-plugin" % pluginVersion)
+}

--- a/plugin/src/sbt-test/coppersmith-plugin/no-dependencies/src/main/scala/hello.scala
+++ b/plugin/src/sbt-test/coppersmith-plugin/no-dependencies/src/main/scala/hello.scala
@@ -1,0 +1,19 @@
+//
+// Copyright 2016 Commonwealth Bank of Australia
+//
+//    Licensed under the Apache License, Version 2.0 (the "License");
+//    you may not use this file except in compliance with the License.
+//    You may obtain a copy of the License at
+//        http://www.apache.org/licenses/LICENSE-2.0
+//    Unless required by applicable law or agreed to in writing, software
+//    distributed under the License is distributed on an "AS IS" BASIS,
+//    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//    See the License for the specific language governing permissions and
+//    limitations under the License.
+//
+
+package commbank.coppersmith.plugin.example
+
+case class Movie(id: String, releaseDate: String)
+
+object FluentMovieFeatures

--- a/plugin/src/sbt-test/coppersmith-plugin/no-dependencies/test
+++ b/plugin/src/sbt-test/coppersmith-plugin/no-dependencies/test
@@ -1,0 +1,4 @@
+> plugins
+-> metadata:export
+-$ exists target/coppersmith-features-0.1-DEMO.json
+-> publishLocal

--- a/plugin/src/sbt-test/coppersmith-plugin/simple/build.sbt
+++ b/plugin/src/sbt-test/coppersmith-plugin/simple/build.sbt
@@ -25,5 +25,8 @@ resolvers ++= Seq(
     if(pluginVersion == null)
       throw new RuntimeException("""|The system property 'plugin.version' is not defined.
                                     |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
-    else libraryDependencies += "au.com.cba.omnia" %% "coppersmith-scalding" % pluginVersion
+    else libraryDependencies ++= Seq("au.com.cba.omnia" %% "coppersmith-core"     % pluginVersion,
+                                     "au.com.cba.omnia" %% "coppersmith-scalding" % pluginVersion,
+                                     "au.com.cba.omnia" %% "coppersmith-tools"    % pluginVersion
+    )
   }

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.20.1"
+version in ThisBuild := "0.21.0"
 
 localVersionSettings


### PR DESCRIPTION
Removes the coppersmith dependency management from the coppersmith plugin. This will require users to define the coppersmith dependencies manually, but will make it easier to avoid transitive dependency clashes.

This PR will also raise a clear error if users attempt to publish metadata without depending on coppersmith.