### PR TITLE
Remove dependency override for shapeless

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,20 @@
 Change log
 ==========
 
+## 0.20.0
+Use the version of shapeless specified by uniform, instead of requiring
+shapeless version `2.2.5`. This is potentially a breaking change for users
+who previously found they needed to add a dependency override to their own
+sbt configuration in order to avoid a `ClassNotFoundException` at runtime.
+
+### Upgrading
+  - Remove the following line, if it appears in your sbt configuration
+    (e.g. `build.sbt` or `project/build.scala`):
+
+```
+dependencyOverrides += "com.chuusai" %% "shapeless" % "2.2.5"
+```
+
 ## 0.19.0
 Change type used in feature sink codec from `FeatureValue[_]` to
 `FeatureValue[Value]`. In practice this shouldn't affect users of

--- a/project/build.scala
+++ b/project/build.scala
@@ -39,8 +39,7 @@ object build extends Build {
       scalacOptions += "-Xfatal-warnings",
       scalacOptions in (Compile, console) ~= (_.filterNot(Set("-Xfatal-warnings", "-Ywarn-unused-import"))),
       scalacOptions in (Compile, doc) ~= (_ filterNot (_ == "-Xfatal-warnings")),
-      scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value,
-      dependencyOverrides += "com.chuusai" %% "shapeless" % "2.2.5" //until maestro is updated
+      scalacOptions in (Test, console) := (scalacOptions in (Compile, console)).value
     )
 
   lazy val all = Project(

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.19.0"
+version in ThisBuild := "0.20.0"
 
 localVersionSettings


### PR DESCRIPTION
No longer required now that we are not using ~~shapeless directly~~ functionality from the newer version of shapeless.

We will need to let users know that they can remove the same override from their own `build.sbt`.