### PR TITLE
Fix type-conformance metadata

### DIFF
--- a/core/src/main/scala/commbank/coppersmith/Feature.scala
+++ b/core/src/main/scala/commbank/coppersmith/Feature.scala
@@ -105,8 +105,8 @@ object Feature {
   // Legal type/value combinations
   @implicitNotFound("Features with value type ${V} cannot be ${T}")
   abstract class Conforms[T <: Type : TypeTag, V <: Value : TypeTag] {
-    def typeTag:  TypeTag[T] = implicitly
-    def valueTag: TypeTag[V] = implicitly
+    def typeTag: TypeTag[T] = implicitly
+    def valueType: Metadata.ValueType = Metadata.valueType[V]
   }
   implicit object NominalStr              extends Conforms[Type.Nominal.type,    Value.Str]
   implicit object OrdinalStr              extends Conforms[Type.Ordinal.type,    Value.Str]
@@ -129,10 +129,10 @@ object Feature {
 
   object Conforms {
 
-    def conforms_?[V <: Value : TypeTag](conforms: Conforms[_, _], metadata: Metadata[_, _]) = {
+    def conforms_?(conforms: Conforms[_, _], metadata: Metadata[_, _]) = {
       def getClazz(tag: TypeTag[_]) = tag.mirror.runtimeClass(tag.tpe.typeSymbol.asClass)
       metadata.featureType.getClass == getClazz(conforms.typeTag) &&
-        metadata.valueType == Metadata.valueType[V]
+        metadata.valueType == conforms.valueType
     }
   }
 

--- a/tools/src/test/scala/commbank/coppersmith/tools/util/ObjectFinderSpec.scala
+++ b/tools/src/test/scala/commbank/coppersmith/tools/util/ObjectFinderSpec.scala
@@ -15,43 +15,52 @@
 import org.specs2.Specification
 
 package commbank.coppersmith.tools.util {
-  trait T
-  trait U
+  trait TT
+  trait UT
+  class TC
+  class UC
 
-  object A extends T
-  object B extends T
-  object C extends U
+  object A extends TC with TT
+  object B extends TC with TT
+  object C extends UC with UT
 
-  trait P[A]
-  trait Q[A] extends P[A]
-  object D extends P[Int]
-  object E extends Q[String]
+  trait PT[A]
+  trait QT[A] extends PT[A]
+  class PC[A]
+  class QC[A] extends PC[A]
+  object D extends PC[Int] with PT[Int]
+  object E extends QC[String] with QT[String]
 
   object F extends someothersillypackage.Outside
 
-  trait V
+  trait VT
+  class VC
   object Outer {
-    object Nested extends V
+    object Nested extends VC with VT
   }
 
   object ObjectFinderSpec extends Specification {
     def is =
       s2"""
         Object finder
-          Can find objects of a given trait $findObjects
-          Can find objects of a given parameterised trait $findObjectsParam
-          Can find objects of a trait from another package $findObjectsTraitOtherPackage
+          Can find objects of a given type $findObjects
+          Can find objects of a given parameterised type $findObjectsParam
+          Can find objects of a type from another package $findObjectsTraitOtherPackage
           Can find nested objects $findNestedObjects
       """
 
     def findObjects = Seq(
-      ObjectFinder.findObjects[T]("commbank.coppersmith.tools.util") === Set(A, B),
-      ObjectFinder.findObjects[U]("commbank.coppersmith.tools.util", "scala") === Set(C)
+      ObjectFinder.findObjects[TT]("commbank.coppersmith.tools.util") === Set(A, B),
+      ObjectFinder.findObjects[TC]("commbank.coppersmith.tools.util") === Set(A, B),
+      ObjectFinder.findObjects[UT]("commbank.coppersmith.tools.util", "scala") === Set(C),
+      ObjectFinder.findObjects[UC]("commbank.coppersmith.tools.util", "scala") === Set(C)
     )
 
     def findObjectsParam = Seq(
-      ObjectFinder.findObjects[Q[_]]("commbank.coppersmith.tools.util") === Set(E),
-      ObjectFinder.findObjects[P[_]]("commbank.coppersmith.tools.util") === Set(D, E)
+      ObjectFinder.findObjects[QT[_]]("commbank.coppersmith.tools.util") === Set(E),
+      ObjectFinder.findObjects[QC[_]]("commbank.coppersmith.tools.util") === Set(E),
+      ObjectFinder.findObjects[PT[_]]("commbank.coppersmith.tools.util") === Set(D, E),
+      ObjectFinder.findObjects[PC[_]]("commbank.coppersmith.tools.util") === Set(D, E)
     )
 
     def findObjectsTraitOtherPackage = Seq(
@@ -64,9 +73,10 @@ package commbank.coppersmith.tools.util {
       ) === Set(F)
     )
 
-    def findNestedObjects = {
-      ObjectFinder.findObjects[V]("commbank.coppersmith.tools.util") === Set(Outer.Nested)
-    }
+    def findNestedObjects = Seq(
+      ObjectFinder.findObjects[VT]("commbank.coppersmith.tools.util") === Set(Outer.Nested),
+      ObjectFinder.findObjects[VC]("commbank.coppersmith.tools.util") === Set(Outer.Nested)
+    )
   }
 }
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.21.1"
+version in ThisBuild := "0.21.2"
 
 localVersionSettings


### PR DESCRIPTION
Fixes two problems:
  1. `ObjectFinder.findObjects` didn't work when the type parameter passed to it was a class, so it would always return the empty set when looking up all `Conforms` instances as it's an abstract class.
  1. The actual `conforms_?` check wasn't comparing the right types for the value.

Also changed to lookup types by `Class`, not name (this would have revealed the first problem earlier in the form of a runtime exception).