### PR TITLE
parseFormatWithOffset -> parseFormatWtihTimezone

### DIFF
--- a/CHANGELOG.markdown
+++ b/CHANGELOG.markdown
@@ -1,6 +1,15 @@
 Change log
 ==========
 
+## 0.22.0
+`Time.parseFormatWithOffset` is now `Time.parseFormatWithTimezone` and
+`Time.unsafeParseFormatWithOffset` is now `Time.unsafeParseFormatWithTimezone`
+to allow specification of timezone identifiers (e.g. Australia/Sydney)
+
+### Upgrading
+  - Change instances of `Time.parseFormatWithOffset` to `Time.parseFormatWithTimezone`
+    and `Time.unsafeParseFormatWithOffset` to `Time.unsafeParseFormatWithTimezone`
+
 ## 0.21.0
 The coppersmith plugin no longer pulls in coppersmith dependencies, so
 that dependency clashes are easier to manage.

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.21.3"
+version in ThisBuild := "0.22.0"
 
 localVersionSettings


### PR DESCRIPTION
This PR allows users to specify a timezone (Australia/Sydney), instead of an explicit offset (+10:00). A feature developer will not know what the exact offset should be at job run time, because of DST and other timezone issues.