### PR TITLE
Expose TestUtil.withoutJavaLogging

### DIFF
--- a/project/build.scala
+++ b/project/build.scala
@@ -25,7 +25,7 @@ import au.com.cba.omnia.uniform.thrift.UniformThriftPlugin._
 import au.com.cba.omnia.uniform.assembly.UniformAssemblyPlugin._
 
 object build extends Build {
-  val maestroVersion = "2.20.0-20160520031836-e06bc75"
+  val maestroVersion = "2.22.0-20160719093316-aa9146e"
 
   // Number of levels of joins supported
   val maxGeneratedJoinSize = 7

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/ScaldingJobSpec.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/ScaldingJobSpec.scala
@@ -53,21 +53,7 @@ class ScaldingJobSpec extends ThermometerHiveSpec with Records { def is = s2"""
       writes feature values for par sets $multiFeatureSetJobPar ${tag("slow")}
   """
 
-  {
-    import java.util.logging.Logger
-    // Suppress parquet logging (which wraps java.util.logging) in tests. Loading the parquet.Log
-    // class forces its static initialiser block to be run prior to removing the root logger
-    // handlers, which needs to be done to avoid the Log's default handler being re-added. Disabling
-    // log output specific to the parquet logger would be more ideal, however, this has proven to be
-    // non-trivial due to what appears to be a result of configuration via static initialisers and
-    // the order in which the initialisers are called.
-    // FIXME: This can be replaced by TestUtil.withoutLogging when slf4j is available in parquet
-    // via https://github.com/apache/parquet-mr/pull/290
-    Logger.getLogger(getClass.getName).info("Suppressing further java.util.logging log output")
-    Class.forName("parquet.Log")
-    val rootLogger = Logger.getLogger("")
-    rootLogger.getHandlers.foreach(rootLogger.removeHandler)
-  }
+  TestUtil.withoutJavaLogging  // suppress parquet logs
 
   def prepareData(
     custAccts:  CustomerAccounts,

--- a/scalding/src/test/scala/commbank/coppersmith/scalding/TestUtil.scala
+++ b/scalding/src/test/scala/commbank/coppersmith/scalding/TestUtil.scala
@@ -33,4 +33,30 @@ object TestUtil {
       loggerLevels.foreach { case (logger, level) => logger.setLevel(level) }
     }
   }
+
+  /** This is intended for use in Thermometer specs, to avoid the logs which parquet spews out.
+    *
+    * It only needs to be called once in the test run (although multiple calls are not harmful).
+    * The recommended usage is to place it in your test class's static initializer block.
+    *
+    * All java.util.logging output will be squashed, with special handling to ensure that parquet does not
+    * later reverse this. As long as everything in the stack that you care about is using a different
+    * logging framework (e.g. SLF4J), then you probably won't mind this overkill to silence parquet.
+    */
+  def withoutJavaLogging() = {
+    import java.util.logging.Logger
+
+    // Suppress parquet logging (which wraps java.util.logging) in tests. Loading the parquet.Log
+    // class forces its static initialiser block to be run prior to removing the root logger
+    // handlers, which needs to be done to avoid the Log's default handler being re-added. Disabling
+    // log output specific to the parquet logger would be more ideal, however, this has proven to be
+    // non-trivial due to what appears to be a result of configuration via static initialisers and
+    // the order in which the initialisers are called.
+    // FIXME: This can be replaced by TestUtil.withoutLogging when slf4j is available in parquet
+    // via https://github.com/apache/parquet-mr/pull/319
+    Logger.getLogger(getClass.getName).info("Suppressing further java.util.logging log output")
+    Class.forName("parquet.Log")
+    val rootLogger = Logger.getLogger("")
+    rootLogger.getHandlers.foreach(rootLogger.removeHandler)
+  }
 }

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.23.4"
+version in ThisBuild := "0.23.5"
 
 localVersionSettings


### PR DESCRIPTION
Extract this workaround from ScaldingJobSpec into TestUtil, so that other projects can use it.