### PR TITLE
Fix apparent race condition with conforms type lookup

### DIFF
--- a/core/src/main/scala/commbank/coppersmith/Feature.scala
+++ b/core/src/main/scala/commbank/coppersmith/Feature.scala
@@ -144,8 +144,11 @@ object Feature {
   // Legal type/value combinations
   @implicitNotFound("Features with value type ${V} cannot be ${T}")
   abstract class Conforms[T <: Type : TypeTag, V <: Value : TypeTag] {
-    def typeTag: TypeTag[T] = implicitly
-    def valueType: Metadata.ValueType = Metadata.valueType[V]
+    val typeTagClass: Class[_] = {
+      val tag: TypeTag[T] = implicitly
+      tag.mirror.runtimeClass(tag.tpe.typeSymbol.asClass)
+    }
+    val valueType: Metadata.ValueType = Metadata.valueType[V]
   }
   implicit object NominalStr              extends Conforms[Type.Nominal.type,    Value.Str]
   implicit object OrdinalStr              extends Conforms[Type.Ordinal.type,    Value.Str]
@@ -169,17 +172,27 @@ object Feature {
   object Conforms {
 
     def conforms_?(conforms: Conforms[_, _], metadata: Metadata[_, _]) = {
-      def getClazz(tag: TypeTag[_]) = tag.mirror.runtimeClass(tag.tpe.typeSymbol.asClass)
-      metadata.featureType.getClass == getClazz(conforms.typeTag) &&
+      metadata.featureType.getClass == conforms.typeTagClass &&
         metadata.valueType == conforms.valueType
     }
 
     // A dynamic ObjectFinder driven approach would be better here, but fails to find any objects
     // in thermometer tests
-    def allConforms: Set[Conforms[_, _]] =
-      Set(ContinuousDecimal, ContinuousFloatingPoint, ContinuousIntegral, DiscreteIntegral,
-        OrdinalDecimal, OrdinalFloatingPoint, OrdinalIntegral, OrdinalStr, NominalBool, NominalIntegral,
-        NominalStr)
+    def allConforms: Set[Conforms[_, _]] = Set(
+      NominalStr,
+      OrdinalStr,
+      OrdinalDecimal,
+      ContinuousDecimal,
+      OrdinalFloatingPoint,
+      ContinuousFloatingPoint,
+      NominalIntegral,
+      OrdinalIntegral,
+      ContinuousIntegral,
+      DiscreteIntegral,
+      InstantDate,
+      InstantTime,
+      NominalBool
+    )
   }
 
   implicit class RichFeature[S : TypeTag, V <: Value : TypeTag](f: Feature[S, V]) {

--- a/core/src/main/scala/commbank/coppersmith/Feature.scala
+++ b/core/src/main/scala/commbank/coppersmith/Feature.scala
@@ -144,6 +144,10 @@ object Feature {
   // Legal type/value combinations
   @implicitNotFound("Features with value type ${V} cannot be ${T}")
   abstract class Conforms[T <: Type : TypeTag, V <: Value : TypeTag] {
+    // This typeTagClass lookup needs to be done at initialisation time (ie, as a val, not a
+    // def) to avoid an apparent race condition that occurs when writing metadata for multiple
+    // feature sets that are executed in parallel. For more context, see:
+    // https://github.com/CommBank/coppersmith/pull/80
     val typeTagClass: Class[_] = {
       val tag: TypeTag[T] = implicitly
       tag.mirror.runtimeClass(tag.tpe.typeSymbol.asClass)

--- a/project/build.scala
+++ b/project/build.scala
@@ -25,7 +25,7 @@ import au.com.cba.omnia.uniform.thrift.UniformThriftPlugin._
 import au.com.cba.omnia.uniform.assembly.UniformAssemblyPlugin._
 
 object build extends Build {
-  val maestroVersion = "2.22.0-20160719093316-aa9146e"
+  val maestroVersion = "2.23.0-20160831010613-9c468cd"
 
   // Number of levels of joins supported
   val maxGeneratedJoinSize = 7

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.23.6"
+version in ThisBuild := "0.23.7"
 
 localVersionSettings


### PR DESCRIPTION
A report has been received of some thermometer tests failing at the
point of writing metadata to sinks, with the following runtime exception:

```
scala.ScalaReflectionException: <none> is not a class
  at scala.reflect.api.Symbols.asClass(Symbols.scala:275)
  at scala.reflect.internal.Symbols.asClass(Symbols.scala:84)
  at commbank.coppersmith.Feature$.getClazz(Feature.scala:172)
```

The error is intermittent, though there appears to be a correlation
with the number of records processed. Moving the `Conforms` type Class
lookup to the object constructor fixes the issue in an otherwise
reproducable failure case.

Also part of this change is adding missing conforms instances to
`allConforms` (and reformatting to make it a little more obvious in the
future), and bringing maestro dependency up to date.