### PR TITLE
Fix big decimal average monoid

### DIFF
--- a/core/src/test/scala/commbank/coppersmith/AggregationSpec.scala
+++ b/core/src/test/scala/commbank/coppersmith/AggregationSpec.scala
@@ -41,12 +41,12 @@ object AggregationSpec extends Specification with ScalaCheck {
     val bigDAvgValLists = nels.map(_.map(BigDAveragedValue(1L, _)))
     val bds = for (bds <- nels; bd <- bds) yield bd
 
-    val expected = BigDAveragedValue(bds.size, bds.list.sum / bds.size)
+    val expected = BigDAveragedValue(bds.size, bds.list.sum)
 
     val aggregationResults = bigDAvgValLists.map(plus)
     val actual = plus(aggregationResults)
 
-    actual.value must beCloseTo(expected.value +/- BigDecimal("0.0000000000000000001"))
+    actual must_== expected
   }}
 
   def plus(vals: NonEmptyList[BigDAveragedValue]) = {

--- a/version.sbt
+++ b/version.sbt
@@ -1,3 +1,3 @@
-version in ThisBuild := "0.25.8"
+version in ThisBuild := "0.25.9"
 
 localVersionSettings


### PR DESCRIPTION
Even though the existing implementation of `BigDAveragedGroup.plus` seems to be associative in theory, it is  not in practice due to precision loss in division operation. Thus the aggregator may yield average value with different precision on different executions over the same data set. 

The new implementation do not calculate intermediate average values so that the division operation happens only once at the end.  